### PR TITLE
お問い合わせ確認ページとお問い合わせ完了ページを連携

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -17,8 +17,9 @@ class ContactController extends Controller
         return view('contact.confirm', ['data' => $data]);
     }
 
-    public function send()
+    public function send(Request $request)
     {
-        return view('contact.thanks');
+        $name = $request->input('name');
+        return view('contact.thanks', ['name' => $name]);
     }
 }

--- a/resources/views/contact/confirm.blade.php
+++ b/resources/views/contact/confirm.blade.php
@@ -41,7 +41,8 @@
                     <div class="p-contact-form__status-panel">完了</div>
                 </div>
                 <div class="p-contact-form__body">
-                    <form class="c-form">
+                    <form class="c-form" action="{{ route('contact.thanks') }}" method="post">
+                        @csrf
                         <div class="c-form__item">
                             <div class="c-form__title">お問い合わせ種別<span class="c-form__require">*必須</span></div>
                             <input type="hidden" name="type" value="{{ $data['type'] }}">

--- a/resources/views/contact/thanks.blade.php
+++ b/resources/views/contact/thanks.blade.php
@@ -39,7 +39,7 @@
                 </div>
                 <div class="p-contact-form__body">
                     <p class="p-contact-form__message">
-                        山田 太郎 さん、お問い合わせありがとうございます。<br>
+                        {{ $name }} さん、お問い合わせありがとうございます。<br>
                         お問い合わせいただいた内容を確認の上、3営業日以内に折り返しご連絡させていただきます。
                     </p>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,4 +28,4 @@ Route::get('recruit', function () {
 
 Route::get('contact', [ContactController::class, 'index'])->name('contact.index');
 Route::post('contact/confirm', [ContactController::class, 'confirm'])->name('contact.confirm');
-Route::get('contact/thanks', [ContactController::class, 'send'])->name('contact.thanks');
+Route::post('contact/thanks', [ContactController::class, 'send'])->name('contact.thanks');


### PR DESCRIPTION
* 作業内容
  * `resources/views/contact/confirm.blade.php`
    * フォームの送信先とメソッドを設定
  * `resources/views/contact/thanks.blade.php`
    * お問い合わせ確認ページから渡ってきた送信者の名前を画面上に表示
  * `app/Http/Controllers/ContactController.php`
    * お問い合わせ確認ページからPOSTメソッドで渡ってきた送信者の名前を、お問い合わせ完了ページに渡す
  * `routes/web.php`
    * ルーティングのメソッドを `post` に変更